### PR TITLE
Add GoogleToolboxForMac framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -85,6 +85,7 @@
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
     <framework src="FirebaseMessaging" type="podspec" spec="~> 2.0.0"/>
+    <framework src="GoogleToolboxForMac" type="podspec" spec="~> 2.1.1"/>
   </platform>
   <platform name="windows">
     <hook type="after_plugin_install" src="hooks/windows/setToastCapable.js"/>


### PR DESCRIPTION
Add GoogleToolboxForMac framework (again)
See: #1715

## Description
Add GoogleToolboxForMac framework to plugin.xml.
This was added in May, but it has disappeared for some reason.

## Related Issue
#1715
https://github.com/phonegap/phonegap-plugin-push/commit/e5739b8721eb7210a333725089fec3b36db5b348

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
